### PR TITLE
Fix deposit balances

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,5 +3,6 @@ import useNavigation from './useNavigation';
 import useFormProgress from './useFormProgress';
 import useKeyboard from './useKeyboard';
 import useTokens from './useTokens';
+import useDeposit from './useDeposit';
 
-export { useTheme, useNavigation, useFormProgress, useKeyboard, useTokens };
+export { useTheme, useNavigation, useFormProgress, useKeyboard, useTokens, useDeposit };

--- a/src/hooks/useDeposit.ts
+++ b/src/hooks/useDeposit.ts
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { depositStablecoins, usdCoin, usdCoinSettingsKey } from '@models/deposit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getTokenBalances } from '@src/services/apis';
+import { useState } from '@hookstate/core';
+import { globalWalletState } from '@stores/WalletStore';
+
+const useDeposit = () => {
+	const [ableToDeposit, setAbleToDeposit] = React.useState<boolean | undefined>();
+	const { address } = useState(globalWalletState()).value;
+
+	useEffect(() => {
+		const checkAbleToDeposit = async () => {
+			const defaultUSDCoin = await usdCoin();
+			const { tokens } = await getTokenBalances(address);
+			const hasTheDefaultToken = !!tokens.find((t) => t.symbol === defaultUSDCoin);
+
+			if (hasTheDefaultToken) {
+				setAbleToDeposit(true);
+			}
+
+			const { symbol } = tokens.find((t) => depositStablecoins.includes(t.symbol)) || {};
+			if (symbol) {
+				await AsyncStorage.setItem(usdCoinSettingsKey, symbol);
+				setAbleToDeposit(true);
+			}
+
+			setAbleToDeposit(false);
+		};
+		checkAbleToDeposit();
+	}, [address]);
+
+	return { ableToDeposit };
+};
+
+export default useDeposit;

--- a/src/model/deposit.ts
+++ b/src/model/deposit.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getTokenBalances } from '@src/services/apis';
 import { formatUnits } from 'ethers/lib/utils';
 import { toBn } from 'evm-bn';
 import { network as selectedNetwork } from './network';
@@ -9,6 +8,7 @@ import { estimateGas } from './wallet';
 const protocol = 'aave-v2';
 export const usdCoinSettingsKey = '@minke:usdcoin';
 export const depositStablecoins = ['USDC', 'DAI', 'USDT'];
+export const interestBearingTokens = ['amusdc', 'amdai', 'amusdt'];
 
 export const fetchAaveMarketData = async (): Promise<Array<AaveMarket>> => {
 	const baseURL = `https://api.zapper.fi/v1/protocols/${protocol}/token-market-data`;
@@ -101,24 +101,6 @@ export const depositTransaction = async ({
 export const usdCoin = async (): Promise<string> => {
 	const coin = await AsyncStorage.getItem(usdCoinSettingsKey);
 	return coin || 'USDC';
-};
-
-export const isAbleToDeposit = async (address: string): Promise<boolean> => {
-	const defaultUSDCoin = await usdCoin();
-	const { tokens } = await getTokenBalances(address);
-	const hasTheDefaultToken = !!tokens.find((t) => t.symbol === defaultUSDCoin);
-
-	if (hasTheDefaultToken) {
-		return true;
-	}
-
-	const { symbol } = tokens.find((t) => depositStablecoins.includes(t.symbol)) || {};
-	if (symbol) {
-		await AsyncStorage.setItem(usdCoinSettingsKey, symbol);
-		return true;
-	}
-
-	return false;
 };
 
 export interface DepositTransaction {

--- a/src/model/token.ts
+++ b/src/model/token.ts
@@ -194,7 +194,9 @@ export interface MinkeToken {
 
 export interface AccountBalance {
 	address: string;
-	balance: number;
+	balance: number; // total
+	depositedBalance: number; // deposited amount
+	walletBalance: number; // available in the wallet (not deposited)
 	tokens: MinkeToken[];
 }
 

--- a/src/model/token.ts
+++ b/src/model/token.ts
@@ -188,7 +188,7 @@ export interface MinkeToken {
 	symbol: string;
 	address: string;
 	image: string;
-	balance: number;
+	balance: string;
 	balanceUSD: number;
 }
 

--- a/src/screens/DepositScreen/Deposit/Deposit.tsx
+++ b/src/screens/DepositScreen/Deposit/Deposit.tsx
@@ -126,7 +126,7 @@ const Deposit = () => {
 	useEffect(() => {
 		if (token && tokens && tokens.length > 0) {
 			const balance = balanceFrom(token);
-			setTokenBalance(balance.toString());
+			setTokenBalance(balance.toFixed(token.decimals));
 		} else {
 			setTokenBalance('0');
 		}

--- a/src/screens/DepositScreen/DepositScreen.tsx
+++ b/src/screens/DepositScreen/DepositScreen.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import { approvalState, isAbleToDeposit } from '@models/deposit';
+import { approvalState } from '@models/deposit';
 import { globalWalletState } from '@stores/WalletStore';
 import { globalDepositState } from '@stores/DepositStore';
 import { Modal, ScreenLoadingIndicator, ModalReusables } from '@components';
-import { useNavigation } from '@hooks';
+import { useDeposit, useNavigation } from '@hooks';
 import Deposit from './Deposit/Deposit';
 import OpenAave from './OpenAave/OpenAave';
 import { NotAbleToSaveModal } from '../WalletScreen/Modals';
@@ -11,7 +11,6 @@ import { NotAbleToSaveModal } from '../WalletScreen/Modals';
 const DepositScreen = () => {
 	const navigation = useNavigation();
 	const [approved, setApproved] = React.useState<boolean | undefined>(); // transaction amount is approved?
-	const [ableToDeposit, setAbleToDeposit] = React.useState<boolean | undefined>();
 	const [notAbleToSaveVisible, setNotAbleToSaveVisible] = React.useState(true);
 	const [addFundsVisible, setAddFundsVisible] = React.useState(false);
 	const {
@@ -19,17 +18,15 @@ const DepositScreen = () => {
 	} = globalDepositState().value;
 	const { address } = globalWalletState().value;
 
+	const { ableToDeposit } = useDeposit();
+
 	useEffect(() => {
-		const checkAbleToDeposit = async () => {
-			setAbleToDeposit(await isAbleToDeposit(address));
-		};
 		const loadApproved = async () => {
 			if (tokens[0]) {
 				const { isApproved } = await approvalState(address, tokens[0].address);
 				setApproved(isApproved);
 			}
 		};
-		checkAbleToDeposit();
 		loadApproved();
 	}, []);
 

--- a/src/screens/ExchangeScreen/ExchangeScreen.tsx
+++ b/src/screens/ExchangeScreen/ExchangeScreen.tsx
@@ -66,7 +66,7 @@ const ExchangeScreen = ({ navigation }: NativeStackScreenProps<RootStackParamLis
 
 	const updateFromToken = (token: ParaswapToken) => {
 		setFromToken(token);
-		setFromTokenBalance(balanceFrom(token).toString());
+		setFromTokenBalance(balanceFrom(token).toFixed(token.decimals));
 		setFromConversionAmount(undefined);
 		exchange.from.set(token);
 		exchange.fromAmount.set(undefined);
@@ -256,8 +256,8 @@ const ExchangeScreen = ({ navigation }: NativeStackScreenProps<RootStackParamLis
 	}, [walletTokens]);
 
 	useEffect(() => {
-		setFromTokenBalance(balanceFrom(fromToken).toString());
-		setToTokenBalance(balanceFrom(toToken).toString());
+		setFromTokenBalance(balanceFrom(fromToken).toFixed(fromToken.decimals));
+		setToTokenBalance(balanceFrom(toToken).toFixed(toToken?.decimals));
 	}, [ownedTokens, exchange.gas.value]);
 
 	useEffect(() => {

--- a/src/screens/WalletAssetsScreen/AssetList/AssetList.tsx
+++ b/src/screens/WalletAssetsScreen/AssetList/AssetList.tsx
@@ -33,7 +33,7 @@ const AssetList: React.FC<AssetListProps> = ({ walletTokens }) => {
 						key={item.address}
 						coinName={item.name}
 						coinSymbol={item.symbol as TokenType}
-						walletBalance={Number(item.balance)}
+						walletBalance={item.balance}
 						walletBalanceUsd={item.balanceUSD}
 						onPress={() => onSelected(item)}
 					/>

--- a/src/screens/WalletAssetsScreen/AssetList/Card/Card.types.ts
+++ b/src/screens/WalletAssetsScreen/AssetList/Card/Card.types.ts
@@ -4,7 +4,7 @@ export interface CardProps {
 	onPress: () => void;
 	coinName: string;
 	coinSymbol: TokenType;
-	walletBalance: number;
+	walletBalance: string;
 	walletBalanceUsd: number;
 	interest?: string;
 }

--- a/src/screens/WalletAssetsScreen/ValueBox/ValueBox.tsx
+++ b/src/screens/WalletAssetsScreen/ValueBox/ValueBox.tsx
@@ -26,7 +26,7 @@ const ValueBox: React.FC<ValueBoxProps> = ({ balance, title }) => (
 		<Header title={title} />
 		<View style={styles.textContainer}>
 			<Text marginBottom={10}>Current value</Text>
-			<Text weight="medium" type="textLarge">
+			<Text weight="medium" type="textLarge" marginBottom={10}>
 				{numberFormat(balance || 0)}
 			</Text>
 		</View>

--- a/src/screens/WalletAssetsScreen/WalletAssetsScreen.tsx
+++ b/src/screens/WalletAssetsScreen/WalletAssetsScreen.tsx
@@ -10,7 +10,7 @@ import styles from './WalletAssetsScreen.styles';
 const WalletAssetsScreen = () => {
 	const { colors } = useTheme();
 	const [addFundsVisible, setAddFundsVisible] = React.useState(false);
-	const { tokens, balance } = useTokens();
+	const { tokens, walletBalance: balance } = useTokens();
 
 	return (
 		<>

--- a/src/screens/WalletScreen/screens/Accounts/Accounts.tsx
+++ b/src/screens/WalletScreen/screens/Accounts/Accounts.tsx
@@ -10,13 +10,14 @@ import styles from './Accounts.styles';
 
 const Accounts = () => {
 	const navigation = useNavigation();
-	const state = useState(globalWalletState());
+	const { balance } = useState(globalWalletState()).value;
 	const { colors } = useTheme();
+
 	return (
 		<View style={styles.tabsNetWorth}>
 			<View style={styles.currentValueCard}>
 				<Text style={styles.cardLabel}>Current value</Text>
-				<Text style={styles.cardBalance}>{numberFormat(state.value.balance?.usd || 0)}</Text>
+				<Text style={styles.cardBalance}>{numberFormat(balance?.usd || 0)}</Text>
 			</View>
 			<Card
 				onPress={() => navigation.navigate('WalletAssetsScreen')}
@@ -28,7 +29,7 @@ const Accounts = () => {
 				right={
 					<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 						<Text weight="bold" style={{ fontSize: 16 }}>
-							{numberFormat(Number(state.value.balance?.usd || '0'))}
+							{numberFormat(balance?.walletBalance || 0)}
 						</Text>
 						<Icon name="arrowForwardStroke" size={16} color="text7" />
 					</View>
@@ -43,8 +44,8 @@ const Accounts = () => {
 				subtitleStyle={{ fontSize: 12, fontWeight: '400' }}
 				right={
 					<View style={{ flexDirection: 'row', alignItems: 'center' }}>
-						<Text color="text7" type="a">
-							Deposit
+						<Text weight="bold" style={{ fontSize: 16 }}>
+							{numberFormat(balance?.depositedBalance || 0)}
 						</Text>
 						<Icon name="arrowForwardStroke" size={16} color="text7" />
 					</View>

--- a/src/services/apis/covalent/covalent.ts
+++ b/src/services/apis/covalent/covalent.ts
@@ -4,6 +4,7 @@ import { convertTokens } from '@src/services/tokenConverter/tokenConverter';
 import coins from '@helpers/coins.json';
 import { network } from '@models/network';
 import { COVALENT_API_KEY } from '@env';
+import { interestBearingTokens } from '@models/deposit';
 import { BalanceApiResponse } from './covalent.types';
 
 const instance = axios.create({
@@ -29,8 +30,12 @@ export const getTokenBalances = async (address: string): Promise<AccountBalance>
 
 	const curated = coins.map(({ symbol }) => symbol.toLowerCase());
 	const minkeTokens = convertTokens({ source: 'covalent', tokens: apiTokens });
-	const tokens = minkeTokens.filter((token) => curated.includes(token.symbol.toLowerCase()));
-	const balance = tokens.map(({ balanceUSD }) => balanceUSD).reduce((a, b) => a + b, 0);
+	let tokens = minkeTokens.filter((token) => curated.includes(token.symbol.toLowerCase()));
+	const interestTokens = tokens.filter((token) => interestBearingTokens.includes(token.symbol.toLowerCase()));
+	tokens = tokens.filter((token) => !interestBearingTokens.includes(token.symbol.toLowerCase()));
+	const walletBalance = tokens.map(({ balanceUSD }) => balanceUSD).reduce((a, b) => a + b, 0);
+	const depositedBalance = interestTokens.map(({ balanceUSD }) => balanceUSD).reduce((a, b) => a + b, 0);
+	const balance = walletBalance + depositedBalance;
 
-	return { address, tokens, balance };
+	return { address, tokens, balance, depositedBalance, walletBalance };
 };

--- a/src/services/tokenConverter/tokenConverter.ts
+++ b/src/services/tokenConverter/tokenConverter.ts
@@ -12,7 +12,7 @@ const convertToken = ({ source, token }: TokenConverterParams): MinkeToken => {
 			return {
 				id,
 				address: token.contract_address,
-				balance: Number(formatUnits(token.balance, token.contract_decimals)),
+				balance: formatUnits(token.balance, token.contract_decimals),
 				balanceUSD: token.quote,
 				decimals: token.contract_decimals,
 				image: token.logo_url,

--- a/src/stores/WalletStore.ts
+++ b/src/stores/WalletStore.ts
@@ -14,7 +14,9 @@ export interface WalletState {
 	walletId?: string | null;
 	balance?: {
 		eth?: BigNumber;
-		usd?: number;
+		usd?: number; // total
+		depositedBalance?: number; // deposits
+		walletBalance?: number; // total in the wallet (total - deposits)
 	};
 	transactions?: Array<Transaction>;
 }
@@ -31,11 +33,13 @@ export const fetchTokensAndBalances = async (privateKey: string, address: string
 	const blockchain = await selectedNetwork();
 	const walletObj = new Wallet(privateKey, await getProvider(blockchain.id));
 	const eth = await walletObj.getBalance();
-	const { balance: balanceUSD } = await getTokenBalances(address);
+	const { balance: balanceUSD, walletBalance, depositedBalance } = await getTokenBalances(address);
 
 	const balance = {
 		eth,
-		usd: balanceUSD
+		usd: balanceUSD,
+		walletBalance,
+		depositedBalance
 	};
 
 	return { balance, network: blockchain };


### PR DESCRIPTION
https://trello.com/c/ploe5Spv/78-deposit-balances

On the accounts tab we should show the deposit balances: [Minke-Defi-App-🐋](https://www.figma.com/file/7TYJ8gFaX6wuUyH1EUsX0D/Minke-Defi-App-%F0%9F%90%8B?node-id=697%3A8023)[](https://www.loom.com/share/17b7db56ce754788a29b9884626edb6e)[](https://www.loom.com/share/17b7db56ce754788a29b9884626edb6e)

Explainer: [Balances explainer](https://www.loom.com/share/17b7db56ce754788a29b9884626edb6e)

Deposit balances should either pull from Aave or the atoken (interest token) value

From the wallet balance (in accounts) we need to subtract any a token balance