### PR TITLE
General improvements

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "8",
+      "buildNumber": "9",
       "config": {
         "usesNonExemptEncryption": false
       },

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Minke",
     "slug": "minke-wallet",
     "owner": "minkelabs",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -19,7 +19,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "7",
+      "buildNumber": "8",
       "config": {
         "usesNonExemptEncryption": false
       },

--- a/ios/MinkeDeFiWallet/Info.plist
+++ b/ios/MinkeDeFiWallet/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.4</string>
+    <string>0.0.5</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSRequiresIPhoneOS</key>

--- a/ios/MinkeDeFiWallet/Info.plist
+++ b/ios/MinkeDeFiWallet/Info.plist
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSRequiresIPhoneOS</key>

--- a/src/containers/AddFunds/AddFunds.hooks.ts
+++ b/src/containers/AddFunds/AddFunds.hooks.ts
@@ -1,7 +1,7 @@
 import React, { createRef, useEffect } from 'react';
 import { TextInput } from 'react-native';
 import { ICoin, coins } from '@helpers/coins';
-import { useAmplitude, useFormProgress, useLanguage, useNavigation, useWyreApplePay } from '@hooks';
+import { useAmplitude, useBiconomy, useFormProgress, useLanguage, useNavigation, useWyreApplePay } from '@hooks';
 import { network } from '@src/model/network';
 import { UseWyreApplePayError } from '@src/hooks/useWyreApplePay/types';
 import { makeOrder, pickPaymentMethodFromName } from '@models/banxa';
@@ -26,6 +26,7 @@ export const useAddFunds = ({ visible, onDismiss }: UseAddFundsProps) => {
 	const { locationCurrency, locationCountry } = useLanguage();
 	const [orderLink, setOrderLink] = React.useState('');
 	const state = useState(globalWalletState());
+	const { gaslessEnabled } = useBiconomy();
 	const { address } = state.value;
 
 	const { onPurchase, orderId, error } = useWyreApplePay();
@@ -45,7 +46,7 @@ export const useAddFunds = ({ visible, onDismiss }: UseAddFundsProps) => {
 	const enableCustomAmount = () => {
 		setAmount(undefined);
 		customAmountRef.current?.focus();
-		goForward();
+		setCurrentStep(2);
 	};
 
 	const dismissCoin = () => {
@@ -113,7 +114,7 @@ export const useAddFunds = ({ visible, onDismiss }: UseAddFundsProps) => {
 		amount,
 		customAmount,
 		customAmountRef,
-		currentStep,
+		currentStep: currentStep === 0 && gaslessEnabled ? currentStep + 1 : currentStep,
 		wyreError,
 		error,
 		orderLink,
@@ -128,6 +129,7 @@ export const useAddFunds = ({ visible, onDismiss }: UseAddFundsProps) => {
 		enableCustomAmount,
 		setCustomAmount,
 		banxaModalVisible,
-		setBanxaModalVisible
+		setBanxaModalVisible,
+		gaslessEnabled
 	};
 };

--- a/src/containers/AddFunds/AddFunds.tsx
+++ b/src/containers/AddFunds/AddFunds.tsx
@@ -30,7 +30,8 @@ const AddFunds: React.FC<AddFundsProps> = ({ visible = false, onDismiss }) => {
 		enableCustomAmount,
 		setCustomAmount,
 		banxaModalVisible,
-		setBanxaModalVisible
+		setBanxaModalVisible,
+		gaslessEnabled
 	} = useAddFunds({ visible, onDismiss });
 
 	const handleGoBack = () => {
@@ -46,7 +47,10 @@ const AddFunds: React.FC<AddFundsProps> = ({ visible = false, onDismiss }) => {
 
 	return (
 		<SafeAreaView>
-			<ModalHeader onBack={handleGoBack} onDismiss={dismissCoin} />
+			<ModalHeader
+				onBack={currentStep === 1 && gaslessEnabled ? undefined : handleGoBack}
+				onDismiss={dismissCoin}
+			/>
 			<View style={{ paddingHorizontal: 24 }}>
 				{wyreError && error ? (
 					<ModalReusables.Error

--- a/src/containers/AddFunds/LocalCurrencyModal/LocalCurrencyModal.tsx
+++ b/src/containers/AddFunds/LocalCurrencyModal/LocalCurrencyModal.tsx
@@ -44,6 +44,7 @@ const LocalCurrencyModal: React.FC<LocalCurrencyModalProps> = ({ onOnramp }) => 
 		fetchPaymentMethodId();
 	}, []);
 
+	const isAmountValid = Number(amount) >= paymentMethodId?.minTopup;
 	return (
 		<View>
 			<Text type="h3" weight="bold" marginBottom={32}>
@@ -52,7 +53,7 @@ const LocalCurrencyModal: React.FC<LocalCurrencyModalProps> = ({ onOnramp }) => 
 
 			<TokenInputInner
 				symbol={locationCountry!.currency}
-				isAmountValid={amount >= paymentMethodId?.minTopup}
+				isAmountValid={isAmountValid}
 				placeholder="0.00"
 				autoFocus
 				showSymbol
@@ -60,19 +61,12 @@ const LocalCurrencyModal: React.FC<LocalCurrencyModalProps> = ({ onOnramp }) => 
 				amount={amount}
 				onChangeText={onChangeText}
 			/>
-
-			{
-				paymentMethodId && (
-					<Text color="text2" type="span" marginBottom={32}>
-						min {paymentMethodId!.minTopup} {locationCountry!.currency}
-					</Text>
-				)
-			}
-
-			<OnrampButton
-				marginBottom={80}
-				onPress={() => onOnramp(number || 0)}
-			/>
+			{paymentMethodId && (
+				<Text color="text2" type="span" marginBottom={32}>
+					Min {paymentMethodId!.minTopup} {locationCountry!.currency}
+				</Text>
+			)}
+			<OnrampButton marginBottom={80} disabled={!isAmountValid} onPress={() => onOnramp(number || 0)} />
 
 			<KeyboardSpacer />
 		</View>

--- a/src/hooks/useAuthentication.ts
+++ b/src/hooks/useAuthentication.ts
@@ -15,8 +15,10 @@ const useAuthentication = (): UseAuthenticationProps => {
 	const showAuthenticationPrompt = async ({ onSuccess, onError }: AuthPrompProps) => {
 		try {
 			// Authenticate user
+			const securityLevel = await LocalAuthentication.getEnrolledLevelAsync();
 			const { success } = await LocalAuthentication.authenticateAsync();
-			if (success) {
+
+			if (success || securityLevel === LocalAuthentication.SecurityLevel.NONE) {
 				await delay(1000);
 				onSuccess();
 			}

--- a/src/hooks/useDepositProtocols.ts
+++ b/src/hooks/useDepositProtocols.ts
@@ -87,11 +87,11 @@ const useDepositProtocols = (withdraw = false) => {
 
 	useEffect(() => {
 		const loadApproved = async () => {
-			if (selectedProtocol && depositableToken) {
+			if (selectedProtocol) {
 				const protocolApproved = await AsyncStorage.getItem(`@approved-${selectedProtocol.id}`);
 				if (protocolApproved) {
 					setApproved(true);
-				} else {
+				} else if (depositableToken) {
 					const { isApproved } = await new DepositService(selectedProtocol.id).approveState(
 						address,
 						gaslessEnabled,
@@ -129,7 +129,7 @@ const useDepositProtocols = (withdraw = false) => {
 
 	useEffect(() => {
 		const updateApy = async () => {
-			if (selectedProtocol) {
+			if (selectedProtocol && selectedUSDCoin) {
 				try {
 					if (selectedProtocol.id === 'aave') {
 						const pools = await getAavePools();
@@ -155,10 +155,9 @@ const useDepositProtocols = (withdraw = false) => {
 				}
 			}
 		};
-		if (depositableToken) {
-			updateApy();
-		}
-	}, [depositableToken]);
+
+		updateApy();
+	}, [selectedProtocol, selectedUSDCoin]);
 
 	return {
 		selectedProtocol,

--- a/src/localization/languages/pt.ts
+++ b/src/localization/languages/pt.ts
@@ -188,7 +188,7 @@ export default {
 	SaveScreen: {
 		interest: '% de juros anuais',
 		EmptyState: {
-			save: 'Salvar',
+			save: 'Investir',
 			open_aave_savings_account: 'Abrir Conta\nde investimentos na %{protocol}',
 			lets_make_first_deposit: 'Vamos fazer seu primeiro depósito?'
 		},

--- a/src/screens/DepositScreen/DepositScreen.tsx
+++ b/src/screens/DepositScreen/DepositScreen.tsx
@@ -13,7 +13,7 @@ const DepositScreen = () => {
 		useDepositScreen();
 	const { selectedProtocol, ableToDeposit, approved, setApproved } = useDepositProtocols();
 
-	if (ableToDeposit === undefined || approved === undefined) {
+	if (ableToDeposit === undefined) {
 		return <ScreenLoadingIndicator />;
 	}
 
@@ -33,6 +33,11 @@ const DepositScreen = () => {
 			</>
 		);
 	}
+
+	if (approved === undefined) {
+		return <ScreenLoadingIndicator />;
+	}
+
 	if (approved) return <Deposit />;
 	return selectedProtocol?.id === 'aave' ? (
 		<OpenAave onApprove={() => setApproved(true)} />


### PR DESCRIPTION
1. Skip coin selector when the network is gasless (if it's gasless you don't need to buy MATIC)
2. Disable on ramp button if the amount is less than the minimal
3. Allow users without a code / fingerprint / face id to do transactions
4. Fix deposits loading forever when the user does not have a depositable token