### PR TITLE
Use the symbol for the 0x API

### DIFF
--- a/src/screens/ExchangeResumeScreen/ExchangeResumeScreen.hooks.ts
+++ b/src/screens/ExchangeResumeScreen/ExchangeResumeScreen.hooks.ts
@@ -61,8 +61,8 @@ const useExchangeResumeScreen = () => {
 
 	const loadPrices = async () => {
 		if (!loading) {
-			const { address: srcToken, decimals: srcDecimals } = from;
-			const { address: destToken, decimals: destDecimals } = to;
+			const { decimals: srcDecimals, symbol: srcToken } = from;
+			const { decimals: destDecimals, symbol: destToken } = to;
 			const { direction = 'from' } = lastConversion || {};
 			const result = await getExchangePrice({
 				address: wallet.address.value,

--- a/src/screens/ExchangeScreen/ExchangeScreen.hooks.ts
+++ b/src/screens/ExchangeScreen/ExchangeScreen.hooks.ts
@@ -57,8 +57,8 @@ export const useExchangeScreen = () => {
 	const loadPrices = async ({ amount = '1', side = 'SELL' }: PriceParams): Promise<Quote | undefined> => {
 		if (fromToken && toToken) {
 			setLoadingPrices(true);
-			const { address: srcToken, decimals: srcDecimals } = fromToken;
-			const { address: destToken, decimals: destDecimals } = toToken;
+			const { symbol: srcToken, decimals: srcDecimals } = fromToken;
+			const { symbol: destToken, decimals: destDecimals } = toToken;
 			const {
 				reason,
 				message,


### PR DESCRIPTION
Fix the MATIC swaps by using the symbol instead of the token address. 

Each API has a different token address for the native token. Some use 0x00000 some use 0xeeeee