### PR TITLE
Removing copy address button from ActionPanel

### DIFF
--- a/src/localization/languages/en.ts
+++ b/src/localization/languages/en.ts
@@ -337,7 +337,6 @@ export default {
 			send: 'Send',
 			exchange: 'Exchange',
 			receive: 'Receive',
-			copy_address: 'Copy address',
 			delete_wallet: 'Delete wallet',
 			are_you_sure: 'Are you sure?',
 			cancel: 'Cancel'

--- a/src/localization/languages/pt.ts
+++ b/src/localization/languages/pt.ts
@@ -337,7 +337,6 @@ export default {
 			send: 'Enviar',
 			exchange: 'Converter',
 			receive: 'Receber',
-			copy_address: 'Copiar endereço',
 			delete_wallet: 'Apagar carteira',
 			are_you_sure: 'Você tem certeza?',
 			cancel: 'Cancelar'

--- a/src/screens/WalletScreen/Content/Content.tsx
+++ b/src/screens/WalletScreen/Content/Content.tsx
@@ -75,8 +75,7 @@ export const Content: React.FC<ContentProps> = ({
 					onDeleteWallet,
 					onExchange,
 					onSwitchAccounts,
-					showReceive,
-					onCopyToClipboard
+					showReceive
 				}}
 				setSendModalOpen={() => setSendModalOpen(true)}
 			/>

--- a/src/screens/WalletScreen/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/screens/WalletScreen/components/ActionsPanel/ActionsPanel.tsx
@@ -11,16 +11,14 @@ const ActionsPanel: React.FC<ActionsPanelProps> = ({
 	onDeleteWallet,
 	onExchange,
 	onSwitchAccounts,
-	showReceive,
-	onCopyToClipboard
+	showReceive
 }) => {
 	const { i18n } = useLanguage();
 
 	const actions = [
 		{ name: i18n.t('WalletScreen.ActionPanel.send'), icon: 'sendStroke' },
 		{ name: i18n.t('WalletScreen.ActionPanel.exchange'), icon: 'exchangeStroke' },
-		{ name: i18n.t('WalletScreen.ActionPanel.receive'), icon: 'receiveStroke' },
-		{ name: i18n.t('WalletScreen.ActionPanel.copy_address'), icon: 'copyStroke' }
+		{ name: i18n.t('WalletScreen.ActionPanel.receive'), icon: 'receiveStroke' }
 	];
 
 	if (__DEV__) {
@@ -35,8 +33,6 @@ const ActionsPanel: React.FC<ActionsPanelProps> = ({
 				return onExchange;
 			case i18n.t('WalletScreen.ActionPanel.receive'):
 				return showReceive;
-			case i18n.t('WalletScreen.ActionPanel.copy_address'):
-				return onCopyToClipboard;
 			case i18n.t('WalletScreen.ActionPanel.switch_accounts'):
 				return onSwitchAccounts;
 			case i18n.t('WalletScreen.ActionPanel.delete_wallet'):

--- a/src/screens/WalletScreen/components/ActionsPanel/ActionsPanel.types.ts
+++ b/src/screens/WalletScreen/components/ActionsPanel/ActionsPanel.types.ts
@@ -7,7 +7,6 @@ interface ActionsPanelProps {
 	onExchange: (event: GestureResponderEvent) => void;
 	onSwitchAccounts: (event: GestureResponderEvent) => void;
 	showReceive: (event: GestureResponderEvent) => void;
-	onCopyToClipboard: (event: GestureResponderEvent) => void;
 }
 
 interface CardProps {


### PR DESCRIPTION
https://trello.com/c/oGrdI47H/159-delete-copy-address-button-from-the-home-screen-ctas-carrousel